### PR TITLE
Update /index.d.ts to fix compilation errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+/// <reference path="./editor/index.d.ts" />
 /// <reference path="./handler/index.d.ts" />
 /// <reference path="./io/index.d.ts" />
 /// <reference path="./layout/index.d.ts" />


### PR DESCRIPTION
Fixes "TS2304: Cannot find name..." for classes under /editor/ when compiling projects depending on "typed-mxgraph".

I encountered the issue while exploring if worth to change my project's dependency from "mxgraph-type-definitions" to "typed--mxgraph".